### PR TITLE
Add build and serve npm tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 ## Webpack - Angular - React sample
 
 ### Setup
-
 1. Run the following script
 
-  ```javascript
-  npm install
-  webpack
   ```
-
-2. Then, serve the files locally, for instance with [http-server](https://www.npmjs.com/package/http-server)
+  npm install
+  npm run build
+  npm run serve
+  ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "babel-core": "^6.3.21",
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",
+    "http-server": "^0.8.5",
     "webpack": "^1.12.9"
+  },
+  "scripts": {
+    "build": "node ./node_modules/webpack/bin/webpack.js",
+    "serve": "node ./node_modules/http-server/bin/http-server"
   },
   "author": "nanovazquez",
   "license": "MIT"


### PR DESCRIPTION
This PR adds two npm tasks to build and serve the sample, it also removes dependency from global webpack module and adds a dependency to `http-server` module to serve sample locally.

![screen shot 2015-12-21 at 3 39 58 pm](https://cloud.githubusercontent.com/assets/1288192/11938361/22bf5aea-a7f9-11e5-80e9-3f5bbd2bdf4a.png)
